### PR TITLE
ブログタイトルのリンクを絶対パスに変更してフラグメント識別子の問題を解決

### DIFF
--- a/src/components/PostRelativeLink.astro
+++ b/src/components/PostRelativeLink.astro
@@ -1,6 +1,6 @@
 ---
-import { Post } from '../lib/interfaces.ts'
-import { getNavLink, getPostLink } from '../lib/blog-helpers.ts'
+import type { Post } from '../lib/interfaces.ts'
+import { getPostLink } from '../lib/blog-helpers.ts'
 import PostTags from './PostTags.astro'
 
 export interface Props {
@@ -35,7 +35,7 @@ const { prevPost, nextPost } = Astro.props
     }
   </div>
   <div>
-    <a href={getNavLink('/')} class="text">↑Top</a>
+    <a href="/" class="text">↑Top</a>
   </div>
 </div>
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,7 +1,7 @@
 ---
 import { PUBLIC_GA_TRACKING_ID, ENABLE_LIGHTBOX } from '../server-constants.ts'
 import { getDatabase } from '../lib/notion/client.ts'
-import { getNavLink, getStaticFilePath, filePath } from '../lib/blog-helpers.ts'
+import { getStaticFilePath, filePath } from '../lib/blog-helpers.ts'
 import '../styles/syntax-coloring.css'
 import GoogleAnalytics from '../components/GoogleAnalytics.astro'
 import CookieConsent from '../components/CookieConsent.astro'
@@ -146,7 +146,7 @@ if (database.Icon && database.Icon.Type === 'file') {
           <div class="content">
             <header>
               <h1>
-                <a href={getNavLink('/')}>
+                <a href="/">
                   {
                     database.Icon && database.Icon.Type === 'emoji' ? (
                       <>


### PR DESCRIPTION
## 概要

ブログのタイトルをクリックしたときに、フラグメント識別子（#以降の文字）が付いてしまい、about:blank#blockedになってしまう問題を修正しました。

## 問題の詳細

- サイトタイトルのリンクがを使用していた
- フラグメント識別子と組み合わさって、リンクが正しく動作しない
- ローカル環境では正常に動作するが、本番環境で問題が発生

## 修正内容

- でサイトタイトルのリンクをからに変更
- でTopリンクをからに変更
- 不要なのインポートを削除
- 絶対パスを使用することで、フラグメント識別子の問題を解決

## テスト

- ローカル環境（http://localhost:4321/）で動作確認済み
- サイトタイトルをクリックすると、正しくTOPページ（/）に遷移することを確認

## 関連Issue

フラグメント識別子が付いてリンクが正しく動作しない問題を解決します。