### PR TITLE
feat: Google AdSense integration

### DIFF
--- a/src/components/AdSenseSidebar.astro
+++ b/src/components/AdSenseSidebar.astro
@@ -1,0 +1,49 @@
+---
+export interface Props {
+  clientId: string
+}
+
+const { clientId = '' } = Astro.props
+const isProd = import.meta.env.PROD
+---
+
+{
+  clientId && isProd && (
+    <div
+      class="adsense-container adsense-hidden"
+      data-testid="adsense-sidebar-ad"
+    >
+      <div class="adsense-label">スポンサーリンク</div>
+      <ins
+        class="adsbygoogle"
+        style="display:block"
+        data-ad-client={clientId}
+        data-ad-slot=""
+        data-ad-format="auto"
+        data-full-width-responsive="true"
+      />
+    </div>
+  )
+}
+
+<style>
+  .adsense-container {
+    margin: 20px 0;
+    text-align: center;
+  }
+
+  .adsense-label {
+    font-size: 0.7rem;
+    color: #999;
+    margin-bottom: 4px;
+    text-align: center;
+  }
+
+  .adsense-hidden {
+    display: none;
+  }
+
+  :global(.dark) .adsense-label {
+    color: #777;
+  }
+</style>

--- a/src/components/CookieConsent.astro
+++ b/src/components/CookieConsent.astro
@@ -13,6 +13,7 @@ const { trackingId } = Astro.props
         <div class="cookie-text">
           <p>
             このウェブサイトでは、ユーザーエクスペリエンスの向上とサイトの分析のためにGoogle Analyticsを使用しています。
+            また、Google AdSenseによる広告を表示しています。
             サイトを利用することで、Cookieの使用に同意したことになります。
           </p>
           <p>
@@ -207,6 +208,9 @@ const { trackingId } = Astro.props
         'analytics_storage': 'granted'
       })
     }
+
+    // Google AdSenseを有効化（カスタムイベント発火）
+    document.dispatchEvent(new CustomEvent('cookie-consent-accepted'))
   }
 
   function declineCookies() {
@@ -219,6 +223,9 @@ const { trackingId } = Astro.props
         'analytics_storage': 'denied'
       })
     }
+
+    // Google AdSenseを無効化（カスタムイベント発火）
+    document.dispatchEvent(new CustomEvent('cookie-consent-declined'))
   }
 
   function hideConsentBanner() {

--- a/src/components/GoogleAdSense.astro
+++ b/src/components/GoogleAdSense.astro
@@ -1,0 +1,70 @@
+---
+export interface Props {
+  clientId: string
+}
+
+const { clientId = '' } = Astro.props
+const isProd = import.meta.env.PROD
+---
+
+{
+  clientId && isProd && (
+    <>
+      {/* AdSense head script - Cookie同意後にのみ有効化 */}
+      <script
+        is:inline
+        define:vars={{ clientId }}
+      >
+        // Cookie同意の確認
+        function getAdSenseCookie(name) {
+          const value = `; ${document.cookie}`
+          const parts = value.split(`; ${name}=`)
+          if (parts.length === 2) return parts.pop().split(';').shift()
+          return null
+        }
+
+        function loadAdSenseScript(id) {
+          // 既にスクリプトが読み込まれている場合はスキップ
+          if (document.querySelector('script[src*="adsbygoogle"]')) return
+
+          const script = document.createElement('script')
+          script.async = true
+          script.crossOrigin = 'anonymous'
+          script.src = `https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${id}`
+          document.head.appendChild(script)
+        }
+
+        function showAdSenseAds() {
+          const adContainers = document.querySelectorAll('.adsense-container')
+          adContainers.forEach(function(container) {
+            container.classList.remove('adsense-hidden')
+          })
+        }
+
+        function hideAdSenseAds() {
+          const adContainers = document.querySelectorAll('.adsense-container')
+          adContainers.forEach(function(container) {
+            container.classList.add('adsense-hidden')
+          })
+        }
+
+        // 初期化: Cookie同意済みの場合はAdSenseを読み込む
+        if (getAdSenseCookie('cookie-consent') === 'accepted') {
+          loadAdSenseScript(clientId)
+          showAdSenseAds()
+        }
+
+        // カスタムイベントリスナー: Cookie同意時にAdSenseを有効化
+        document.addEventListener('cookie-consent-accepted', function() {
+          loadAdSenseScript(clientId)
+          showAdSenseAds()
+        })
+
+        // カスタムイベントリスナー: Cookie拒否時にAdSenseを非表示
+        document.addEventListener('cookie-consent-declined', function() {
+          hideAdSenseAds()
+        })
+      </script>
+    </>
+  )
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,9 +1,11 @@
 ---
-import { PUBLIC_GA_TRACKING_ID, ENABLE_LIGHTBOX } from '../server-constants.ts'
+import { PUBLIC_GA_TRACKING_ID, ENABLE_LIGHTBOX, ENABLE_ADSENSE, PUBLIC_ADSENSE_CLIENT_ID } from '../server-constants.ts'
 import { getDatabase } from '../lib/notion/client.ts'
 import { getStaticFilePath, filePath } from '../lib/blog-helpers.ts'
 import '../styles/syntax-coloring.css'
 import GoogleAnalytics from '../components/GoogleAnalytics.astro'
+import GoogleAdSense from '../components/GoogleAdSense.astro'
+import AdSenseSidebar from '../components/AdSenseSidebar.astro'
 import CookieConsent from '../components/CookieConsent.astro'
 import SearchModal from '../components/SearchModal.astro'
 import SearchButton from '../components/SearchButton.astro'
@@ -132,6 +134,7 @@ if (database.Icon && database.Icon.Type === 'file') {
   <body>
     <ThemeToggle />
     <GoogleAnalytics trackingId={PUBLIC_GA_TRACKING_ID} />
+    {ENABLE_ADSENSE && <GoogleAdSense clientId={PUBLIC_ADSENSE_CLIENT_ID} />}
     <CookieConsent trackingId={PUBLIC_GA_TRACKING_ID} />
     <div class="container">
       <header>
@@ -200,6 +203,7 @@ if (database.Icon && database.Icon.Type === 'file') {
             <Profile />
           <SearchButton />
           <slot name="aside" />
+          {ENABLE_ADSENSE && <AdSenseSidebar clientId={PUBLIC_ADSENSE_CLIENT_ID} />}
         </aside>
       </div>
     </div>

--- a/src/server-constants.ts
+++ b/src/server-constants.ts
@@ -45,3 +45,7 @@ export const CF_PAGES_BRANCH = import.meta.env.CF_PAGES_BRANCH || process.env.CF
 export const DEFAULT_CUSTOM_DOMAIN = 'midnight480.com'
 export const FORCE_HTTPS = true
 export const ENABLE_CANONICAL_REDIRECT = true
+
+// Google AdSense設定
+export const ENABLE_ADSENSE = import.meta.env.ENABLE_ADSENSE === 'true'
+export const PUBLIC_ADSENSE_CLIENT_ID = import.meta.env.PUBLIC_ADSENSE_CLIENT_ID || ''


### PR DESCRIPTION
## Summary
Google AdSenseをサイドバーに設置し、Cookie同意ベースで制御する機能を追加。

## Changes
- **新規**: `src/components/GoogleAdSense.astro` - AdSenseスクリプト管理コンポーネント
- **新規**: `src/components/AdSenseSidebar.astro` - サイドバー広告ユニットコンポーネント
- **修正**: `src/server-constants.ts` - ENABLE_ADSENSE, PUBLIC_ADSENSE_CLIENT_ID定数追加
- **修正**: `src/layouts/Layout.astro` - AdSenseコンポーネント統合
- **修正**: `src/components/CookieConsent.astro` - AdSense同意連携追加

## Features
- Cookie同意を得た場合のみAdSenseスクリプトを動的読み込み
- 本番環境のみでスクリプト読み込み（開発環境では無効）
- 環境変数 `ENABLE_ADSENSE` でON/OFF制御
- 環境変数 `PUBLIC_ADSENSE_CLIENT_ID` でClient ID管理
- ダークモード対応
- 「スポンサーリンク」ラベル表示

## Testing
- TypeScript診断: 新規・修正ファイルにエラーなし
- 既存テストへの影響なし

## Environment Variables Required
- `ENABLE_ADSENSE=true`
- `PUBLIC_ADSENSE_CLIENT_ID=ca-pub-XXXXXXXXXXXXXXXX`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

**新機能**
- Google AdSenseの統合により、サイトにスポンサーリンク広告を表示可能に。
- クッキー同意画面がGoogle AdSenseに対応。AdSense広告はユーザーの同意後に読み込まれます。
- 本番環境での環境変数設定により、AdSenseの有効化・無効化をコントロール可能。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->