### PR TITLE
docs: AGENTS.md を追加し PR 運用ルールを明文化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+## リポジトリ構成
+
+このリポジトリは [otoyo/astro-notion-blog](https://github.com/otoyo/astro-notion-blog) の fork です。
+
+| remote | URL | 用途 |
+| --- | --- | --- |
+| `origin` | `midnight480/astro-notion-blog` | 自分のリポジトリ。**作業対象はここだけ** |
+| `upstream` | `otoyo/astro-notion-blog` | fork 元。参照専用 |
+
+## PR・ブランチ運用ルール
+
+**PR、ブランチ、issue は必ず `midnight480/astro-notion-blog`（`origin`）に対してのみ作成すること。**
+fork 元である `upstream`（`otoyo/astro-notion-blog`）へは、明示的に指示された場合を除き
+絶対に PR を作成しないこと。
+
+`gh` は fork リポジトリでは**既定で親リポジトリ（upstream）を対象にする**ため、
+`gh pr create` / `gh issue create` などでは必ず `--repo` を明示する:
+
+```bash
+gh pr create --repo midnight480/astro-notion-blog --base main --head <branch> ...
+```
+
+`--repo` を省略すると `No commits between main and <branch>` のようなエラーになるか、
+最悪の場合 fork 元へ意図しない PR が飛ぶ。
+
+同様に push 先も `origin` を明示する:
+
+```bash
+git push -u origin <branch>
+```
+
+## 開発コマンド
+
+```bash
+npm run dev              # 開発サーバー
+npm run build            # ビルド（Notion API アクセスが必要）
+npm run build:skip-cache # キャッシュ取得をスキップしてビルド
+npm run lint             # eslint src
+npm run format           # prettier
+npm run test:all         # SEO / リダイレクト / E2E テスト一式
+```
+
+ビルドには有効な Notion API トークン（`.env`）が必要。
+トークンが無効だと `astro:build:start` の integration hook で失敗する。
+
+## スタイル定義の注意点
+
+`:global()` は **CSS Modules 専用の構文**であり、プレーンな CSS ファイルでは
+不正セレクタとして扱われてルールごと無効になる。
+
+- `src/styles/*.module.css` … CSS Module。`:global()` を使ってよい
+- 上記以外の `src/styles/*.css` … グローバル CSS。`:global()` を使わず通常のセレクタを書く
+  （例: `:global(html.dark) .foo` ではなく `html.dark .foo`）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# CLAUDE.md
+
+このプロジェクトの指示は `AGENTS.md` に集約しています。
+以下の import により、セッション開始時に `AGENTS.md` の内容が読み込まれます。
+
+@AGENTS.md


### PR DESCRIPTION
エージェント向けのプロジェクト指示ファイル `AGENTS.md` を追加します。

## 背景

このリポジトリは [otoyo/astro-notion-blog](https://github.com/otoyo/astro-notion-blog) の fork ですが、`gh` は fork では**既定で親リポジトリ（upstream）を対象にする**ため、PR #138 の作成時に upstream 側へ PR を作ろうとして失敗しました。

```
pull request create failed: GraphQL: ... No commits between main and fix/build-warnings-astro-7.1
```

`--repo` を明示して解決しましたが、条件次第では **fork 元へ意図しない PR が飛ぶ**リスクがあるため、運用ルールとして明文化します。

## 追加内容

### `AGENTS.md`（本体）
- **リポジトリ構成** … `origin` = `midnight480`（作業対象）、`upstream` = `otoyo`（参照専用）
- **PR・ブランチ運用ルール** … PR / ブランチ / issue は `origin` にのみ作成。upstream へは明示指示がない限り作成禁止。`gh` では `--repo` を必ず明示
- **開発コマンド** … ビルドには有効な Notion API トークンが必要な点も記載
- **スタイル定義の注意点** … `:global()` は CSS Modules 専用構文であり、プレーン CSS で使うとルールごと無効になる（PR #138 で実際に踏んだ問題）

### `CLAUDE.md`（参照のみ）
Claude Code は `CLAUDE.md` しか読まず `AGENTS.md` のネイティブサポートが無いため、`@AGENTS.md` の import 構文で参照する構成にしています（[公式ドキュメント](https://code.claude.com/docs/en/memory.md)）。

```markdown
@AGENTS.md
```

ファイル名を他ツール共通の事実上の標準である `AGENTS.md`（複数形）にすることで、Cursor や Codex など他のエージェントも同じファイルを直接参照できます。

## 補足

ドキュメントのみの変更で、ビルド・アプリケーションコードへの影響はありません。
PR #138（ビルド警告修正 + Astro 7.1.2）とは独立したブランチです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)